### PR TITLE
Add a Terraform set up to template the AWS ECS deployment.

### DIFF
--- a/deploy-server.sh
+++ b/deploy-server.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+set -euo pipefail;
+
+TERRAFORM_DIR=./terraform
+if which terraform > /dev/null; then
+    echo "Found terraform. Applying the config stored at: ${TERRAFORM_DIR}";
+else
+    echo "Unable to find terraform on the system path. Are you sure you have it installed?";
+    exit 1
+fi
+
+TERRAFORM_TFVARS_FILE=terraform.tfvars
+if test -f "$TERRAFORM_TFVARS_FILE"; then
+    echo "$TERRAFORM_TFVARS_FILE exists. Proceeding with deployment.";
+else
+    echo "$TERRAFORM_TFVARS_FILE does not exist. Using the terraform.tfvars.sample file for the required input variables.";
+    TERRAFORM_TFVARS_FILE=terraform.tfvars.sample
+fi
+
+terraform -chdir=${TERRAFORM_DIR} init;
+terraform -chdir=${TERRAFORM_DIR} apply -var-file $TERRAFORM_TFVARS_FILE;
+
+echo "Deployment complete. You may now access the server at the \"dns_name\" provided in the output."

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,4 @@
+terraform.tfvars
+*.tfstate
+**/.terraform/*
+*.tfstate.*

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "2.70.4"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:AL1FQlgxRIAHNNVErC75Coo11irvRq8Zr+fUSISS2Mo=",
+    "zh:45f528103c5580623b15e7ac3986b72baa5d33cabc66c902594d666c7607a8f2",
+    "zh:538793ad294171370cc0c280c98cb5c8eb77669d0917c2ab727090016ec2626e",
+    "zh:631d5aea6ec7b13d8973f13fc70dc36ecc5e5614793c5141ccd254773bc4ec36",
+    "zh:7861c5e12c322717ff9684ac658be590d12906a9549204b6337f3f8d55bf0640",
+    "zh:8adfe014d0a0552a9a6b358cc0d7e3d0c660bc15aa5524e771525b0e5d14b20f",
+    "zh:9d81089842c0990d410bffc5702dec719145951c3f5cbc85c3bf8968985d50cc",
+    "zh:a4b0922e0fddccbb84958d4909896e8009c57885a41cc2e1c37dcdc56e2da796",
+    "zh:a6dcd0292e807d8d5b8a922d2e0cc3c6949461e18603cb48005c967329abe574",
+    "zh:ae07e0dae4e700c1f6623bd0b66ab4153d0b498ffd5f6681117101d2020815bc",
+    "zh:bd07ba17501b8b57d4455329770f4f520e709d12f8b0c364821f39d1b2df1a89",
+    "zh:ddbf1a0b63ac84462da002b44b249f86180804670f1070109785d00a19f88e16",
+    "zh:e2291e9efbd0100c555d3bae8f2b2af4d416f80105c250747cb5fd8f0b17062f",
+    "zh:e5d8e0ad489547118fd76f300d1cb6dd516997cf919dc0bbaedaacb5c91e697a",
+    "zh:eae90e616cec391546bf4ecf294e8a3ae56ce7c90ac0e1d45ebf2907957b9f16",
+  ]
+}

--- a/terraform/clusters.tf
+++ b/terraform/clusters.tf
@@ -1,4 +1,5 @@
 
+// Straightforward cluster definition. Might not need any more clusters in the future.
 resource "aws_ecs_cluster" "my_default_cluster" {
     name = "my-default-cluster"   
 }

--- a/terraform/clusters.tf
+++ b/terraform/clusters.tf
@@ -1,5 +1,5 @@
 
 // Straightforward cluster definition. Might not need any more clusters in the future.
 resource "aws_ecs_cluster" "my_default_cluster" {
-    name = "my-default-cluster"   
+    name = var.project_name   
 }

--- a/terraform/clusters.tf
+++ b/terraform/clusters.tf
@@ -1,0 +1,4 @@
+
+resource "aws_ecs_cluster" "my_default_cluster" {
+    name = "my-default-cluster"   
+}

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,3 +1,4 @@
+// Create a load balancer that will be used to route traffic to the markdown server.
 resource "aws_alb" "markdown_server_load_balancer" {
     name = "markdown-server-load-balancer"
     load_balancer_type = "application"
@@ -8,9 +9,12 @@ resource "aws_alb" "markdown_server_load_balancer" {
         "${aws_default_subnet.default_subnet_c.id}"
     ]
 
+    // This security group defines the network ingress/egress for the load balancer.
     security_groups = ["${aws_security_group.load_balancer_security_group.id}"]
 }
 
+// Allow inbound traffic at port 80 (for the load balancer), and let it
+// communicate with the markdown server instances.
 resource "aws_security_group" "load_balancer_security_group" {
     ingress {
         from_port = 80
@@ -27,12 +31,15 @@ resource "aws_security_group" "load_balancer_security_group" {
     }
 }
 
-
+// Allow the markdown_server instances to be freely able to communicate with anything
+// since they're only really allowed access by the load balancer.
 resource "aws_security_group" "markdown_server_security_group" {
     ingress {
         from_port = 0
         to_port = 0
         protocol = "-1"
+        // Ensure anything that talks to the markdown-server is itself in the same security group
+        // as the load balancer.
         security_groups = ["${aws_security_group.load_balancer_security_group.id}"]
     }
 
@@ -44,12 +51,27 @@ resource "aws_security_group" "markdown_server_security_group" {
     }
 }
 
+// Create a target group of servers that the load balancer can point to.
 resource "aws_lb_target_group" "markdown_server_target_group" {
     name = "markdown-server-target-group"
+    // The load balancer that this target group will be associated with.
+    // This is a dependency because the target group can't be created until the load balancer
+    // has been created.
+    depends_on = [
+      aws_alb.markdown_server_load_balancer
+    ]
+
+    // The port that the targets (i.e. server instances) will receive traffic on.
+    // :sus: that they're required with `target_type = "ip"` but our servers
+    // are actually running on port 9003.
+    // meh. it works as is, why break it.
     port = 80
     protocol = "HTTP"
     target_type = "ip"
+
     vpc_id = "${aws_default_vpc.default_vpc.id}"
+
+    // This is how the server instances report they are healthy.
     health_check {
         path = "/"
         interval = 15
@@ -61,6 +83,7 @@ resource "aws_lb_target_group" "markdown_server_target_group" {
     }
 }
 
+// Create a listener that will listen for traffic on port 80 and forward it to the target group.
 resource "aws_lb_listener" "markdown_server_listener" {
     load_balancer_arn = "${aws_alb.markdown_server_load_balancer.arn}"
     port = 80

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,0 +1,72 @@
+resource "aws_alb" "markdown_server_load_balancer" {
+    name = "markdown-server-load-balancer"
+    load_balancer_type = "application"
+
+    subnets = [
+        "${aws_default_subnet.default_subnet_a.id}", 
+        "${aws_default_subnet.default_subnet_b.id}", 
+        "${aws_default_subnet.default_subnet_c.id}"
+    ]
+
+    security_groups = ["${aws_security_group.load_balancer_security_group.id}"]
+}
+
+resource "aws_security_group" "load_balancer_security_group" {
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+        from_port = 0
+        to_port = 0
+        protocol = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+
+resource "aws_security_group" "markdown_server_security_group" {
+    ingress {
+        from_port = 0
+        to_port = 0
+        protocol = "-1"
+        security_groups = ["${aws_security_group.load_balancer_security_group.id}"]
+    }
+
+    egress {
+        from_port = 0
+        to_port = 0
+        protocol = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_lb_target_group" "markdown_server_target_group" {
+    name = "markdown-server-target-group"
+    port = 80
+    protocol = "HTTP"
+    target_type = "ip"
+    vpc_id = "${aws_default_vpc.default_vpc.id}"
+    health_check {
+        path = "/"
+        interval = 15
+        timeout = 5
+        healthy_threshold = 2
+        unhealthy_threshold = 2
+        port = 9005
+        matcher = "200,301,302"
+    }
+}
+
+resource "aws_lb_listener" "markdown_server_listener" {
+    load_balancer_arn = "${aws_alb.markdown_server_load_balancer.arn}"
+    port = 80
+    protocol = "HTTP"
+    default_action {
+        type = "forward"
+        target_group_arn = "${aws_lb_target_group.markdown_server_target_group.arn}"
+    }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,3 +11,7 @@ terraform {
 provider "aws" {
     region = "us-east-1"
 }
+
+output "dns_name" {
+    value = aws_alb.server_load_balancer.dns_name
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,17 @@
+terraform {
+    required_providers {
+        aws = {
+            source = "hashicorp/aws"
+            version = "~> 2.0"
+        }
+    }
+}
+
+
+provider "aws" {
+    region = "us-east-1"
+}
+
+resource "aws_ecs_cluster" "my_sandbox_cluster" {
+    name = "my-sandbox-cluster"   
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,7 +11,3 @@ terraform {
 provider "aws" {
     region = "us-east-1"
 }
-
-resource "aws_ecs_cluster" "my_sandbox_cluster" {
-    name = "my-sandbox-cluster"   
-}

--- a/terraform/networks.tf
+++ b/terraform/networks.tf
@@ -1,3 +1,6 @@
+// Not creating any VPCs or subnets but obtaining references
+// to them so that we can use them elsewhere.
+
 resource "aws_default_vpc" "default_vpc" {}
 
 resource "aws_default_subnet" "default_subnet_a" {

--- a/terraform/networks.tf
+++ b/terraform/networks.tf
@@ -1,0 +1,11 @@
+resource "aws_default_vpc" "default_vpc" {}
+
+resource "aws_default_subnet" "default_subnet_a" {
+    availability_zone = "us-east-1a"
+}
+resource "aws_default_subnet" "default_subnet_b" {
+    availability_zone = "us-east-1b"
+}
+resource "aws_default_subnet" "default_subnet_c" {
+    availability_zone = "us-east-1c"
+}

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -1,0 +1,19 @@
+resource "aws_iam_role" "ecsTaskExecutionRole" {
+    name = "ecsTaskExecutionRole1"
+    assume_role_policy = "${data.aws_iam_policy_document.assume_role_policy.json}"
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+    statement {
+        actions = ["sts:AssumeRole"]
+        principals {
+            type = "Service"
+            identifiers = ["ecs-tasks.amazonaws.com"]
+        }
+    }
+}
+
+resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole_policy" {
+  role       = "${aws_iam_role.ecsTaskExecutionRole.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -1,3 +1,7 @@
+// Some ecs task execution role stuff I'm not sure about but
+// apparently its required to deploy tasks on ecs.
+// Andrew says you gotta do this so who am I to question Andrew?
+// https://medium.com/avmconsulting-blog/how-to-deploy-a-dockerised-node-js-application-on-aws-ecs-with-terraform-3e6bceb48785
 resource "aws_iam_role" "ecsTaskExecutionRole" {
     name = "ecsTaskExecutionRole1"
     assume_role_policy = "${data.aws_iam_policy_document.assume_role_policy.json}"

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -3,7 +3,7 @@
 // Andrew says you gotta do this so who am I to question Andrew?
 // https://medium.com/avmconsulting-blog/how-to-deploy-a-dockerised-node-js-application-on-aws-ecs-with-terraform-3e6bceb48785
 resource "aws_iam_role" "ecsTaskExecutionRole" {
-    name = "ecsTaskExecutionRole1"
+    name = "${var.project_name}-ecsTaskExecutionRole"
     assume_role_policy = "${data.aws_iam_policy_document.assume_role_policy.json}"
 }
 

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -1,0 +1,26 @@
+resource "aws_ecs_service" "markdown_server" {
+    name = "markdown-server"
+    cluster = "${aws_ecs_cluster.my_default_cluster.id}"
+    task_definition = "${aws_ecs_task_definition.markdown_server.arn}"
+    launch_type = "FARGATE"
+    desired_count = 3
+
+    load_balancer {
+        target_group_arn = "${aws_lb_target_group.markdown_server_target_group.arn}"
+        container_name = "${aws_ecs_task_definition.markdown_server.family}"
+        container_port = 9003
+    }
+
+    network_configuration {
+        subnets = [
+            "${aws_default_subnet.default_subnet_a.id}", 
+            "${aws_default_subnet.default_subnet_b.id}", 
+            "${aws_default_subnet.default_subnet_c.id}"
+        ]
+        security_groups = [
+            "${aws_security_group.load_balancer_security_group.id}",
+            "${aws_security_group.markdown_server_security_group.id}"
+        ]
+        assign_public_ip = true
+    }
+}

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -3,19 +3,19 @@
 // and a cluster. The service will be deployed to the cluster and will use the
 // task definition to define the containers that will be deployed.
 
-resource "aws_ecs_service" "markdown_server" {
-    name = "markdown-server"
+resource "aws_ecs_service" "server" {
+    name = var.project_name
     cluster = "${aws_ecs_cluster.my_default_cluster.id}"
-    task_definition = "${aws_ecs_task_definition.markdown_server.arn}"
+    task_definition = "${aws_ecs_task_definition.server.arn}"
     launch_type = "FARGATE"
     desired_count = 3
 
     // We want the service to be load-balanced by our server load balancer
     // and we wanna register the instances we create with the target group.
     load_balancer {
-        target_group_arn = "${aws_lb_target_group.markdown_server_target_group.arn}"
-        container_name = "${aws_ecs_task_definition.markdown_server.family}"
-        container_port = 9003
+        target_group_arn = "${aws_lb_target_group.server_target_group.arn}"
+        container_name = "${aws_ecs_task_definition.server.family}"
+        container_port = var.container_port
     }
 
     // The subnets are the availability zones and the security groups are the
@@ -31,7 +31,7 @@ resource "aws_ecs_service" "markdown_server" {
         ]
         security_groups = [
             "${aws_security_group.load_balancer_security_group.id}",
-            "${aws_security_group.markdown_server_security_group.id}"
+            "${aws_security_group.server_security_group.id}"
         ]
         assign_public_ip = true
     }

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -1,3 +1,8 @@
+
+// The meat of this deployment. Define a service by selecting a task definition
+// and a cluster. The service will be deployed to the cluster and will use the
+// task definition to define the containers that will be deployed.
+
 resource "aws_ecs_service" "markdown_server" {
     name = "markdown-server"
     cluster = "${aws_ecs_cluster.my_default_cluster.id}"
@@ -5,12 +10,19 @@ resource "aws_ecs_service" "markdown_server" {
     launch_type = "FARGATE"
     desired_count = 3
 
+    // We want the service to be load-balanced by our server load balancer
+    // and we wanna register the instances we create with the target group.
     load_balancer {
         target_group_arn = "${aws_lb_target_group.markdown_server_target_group.arn}"
         container_name = "${aws_ecs_task_definition.markdown_server.family}"
         container_port = 9003
     }
 
+    // The subnets are the availability zones and the security groups are the
+    // ingress/egress rules for the instances. We'll give them both the load balancer
+    // security group and the markdown server security group so that the load balancer
+    // can talk to the markdown server instances and the markdown server instances can
+    // do whatever they please.
     network_configuration {
         subnets = [
             "${aws_default_subnet.default_subnet_a.id}", 

--- a/terraform/tasks.tf
+++ b/terraform/tasks.tf
@@ -1,0 +1,34 @@
+resource "aws_ecs_task_definition" "markdown_server" {
+    family = "markdown-server"
+    container_definitions = <<DEFINITION
+    [
+        {
+            "name": "markdown-server",
+            "image": "aalekhpatel07/ws-markdown-server:1.0.2",
+            "essential": true,
+            "portMappings": [
+                {
+                    "containerPort": 9003,
+                    "hostPort": 9003
+                },
+                {
+                    "containerPort": 9004,
+                    "hostPort": 9004
+                },
+                {
+                    "containerPort": 9005,
+                    "hostPort": 9005
+                }
+            ],
+            "memory": 512,
+            "cpu": 256
+        }
+    ]
+    DEFINITION
+
+    requires_compatibilities = [ "FARGATE" ]
+    network_mode = "awsvpc"
+    memory = 512
+    cpu = 256
+    execution_role_arn = "${aws_iam_role.ecsTaskExecutionRole.arn}"
+}

--- a/terraform/tasks.tf
+++ b/terraform/tasks.tf
@@ -2,13 +2,13 @@
 // The core variable for this deployment. Define the task
 // using a docker image, the ports it will use, and the
 // resources it will need.
-resource "aws_ecs_task_definition" "markdown_server" {
-    family = "markdown-server"
+resource "aws_ecs_task_definition" "server" {
+    family = var.project_name
     container_definitions = <<DEFINITION
     [
         {
-            "name": "markdown-server",
-            "image": "aalekhpatel07/ws-markdown-server:1.0.2",
+            "name": "${var.project_name}",
+            "image": "${var.docker_image}",
             "essential": true,
             "portMappings": [
                 {

--- a/terraform/tasks.tf
+++ b/terraform/tasks.tf
@@ -1,3 +1,7 @@
+
+// The core variable for this deployment. Define the task
+// using a docker image, the ports it will use, and the
+// resources it will need.
 resource "aws_ecs_task_definition" "markdown_server" {
     family = "markdown-server"
     container_definitions = <<DEFINITION

--- a/terraform/terraform.tfvars.sample
+++ b/terraform/terraform.tfvars.sample
@@ -1,0 +1,5 @@
+project_name = "markdown-server"
+container_port = 9003
+docker_image = "aalekhpatel07/ws-markdown-server:1.0.2"
+healthcheck_port = 9005
+healthcheck_path = "/"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,24 @@
+variable "project_name" {
+  description = "Some prefix to namespace the resources for the project if shipping a server binary."
+  type = string
+}
+
+variable "docker_image" {
+    description = "The docker image to use for the server."
+  type = string
+}
+
+variable "container_port" {
+    description = "The port the container will listen on."
+  type = number
+}
+
+variable "healthcheck_port" {
+    description = "The port the healthcheck will listen on."
+    type = number
+}
+
+variable "healthcheck_path" {
+    description = "The path the healthcheck will listen on."
+    type = string
+}


### PR DESCRIPTION
- Add basic ECS deployment setup with terraform
- Comment the functioning setup for later usage and reference.
- Refactor key vars into a variables.tf and terraform.tfvars file. Commit a sample of the tfvars file.
- Add a handy script to run terraform commands to bootstrap the AWS ECS deployment.
